### PR TITLE
Update transducer.py: input dimension of joiner Linear

### DIFF
--- a/rnnt/transducer.py
+++ b/rnnt/transducer.py
@@ -90,7 +90,7 @@ class RNNTransducer(nn.Module):
             eos_id=eos_id,
             dropout_p=decoder_dropout_p,
         )
-        self.fc = Linear(decoder_hidden_state_dim, num_classes, bias=False)
+        self.fc = Linear(out_dim * 2, num_classes, bias=False)
 
     def set_encoder(self, encoder):
         """ Setter for encoder """


### PR DESCRIPTION
the input dimension of linear joiner should be additive of encoder + decoder output.

Is it correct?